### PR TITLE
fix series linking

### DIFF
--- a/extensions/cornerstone/src/initSeriesLinking.js
+++ b/extensions/cornerstone/src/initSeriesLinking.js
@@ -86,7 +86,11 @@ const initSeriesLinking = ({ servicesManager, commandsManager }) => {
         let angleInRadians = sourceNormal.angleTo(targetNormal);
         angleInRadians = Math.abs(angleInRadians);
 
-        if (angleInRadians !== 0) {
+        /*
+        TODO: Replace this check with approximatelyEquals after
+        cornerstone-math PR merged
+        */
+        if (angleInRadians > 0.0001) {
           return;
         }
 


### PR DESCRIPTION
The purpose of this change is to fix series linking in our viewer. This change is somewhat temporary as we will replace the angle check with the approximatelyEquals function from cornerstone-math as soon as the following PR is merged and deployed:

https://github.com/cornerstonejs/cornerstoneMath/pull/53
