### PR TITLE
Fix reference lines

### DIFF
--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -32,7 +32,7 @@
     "@ohif/core": "^0.50.0",
     "@ohif/ui": "^0.50.0",
     "cornerstone-core": "^2.3.0",
-    "cornerstone-math": "^0.1.9",
+    "cornerstone-math": "0.1.10",
     "cornerstone-tools": "5.1.2",
     "cornerstone-wado-image-loader": "^3.1.2",
     "dcmjs": "0.16.1",

--- a/extensions/cornerstone/src/initReferenceLines.js
+++ b/extensions/cornerstone/src/initReferenceLines.js
@@ -3,10 +3,12 @@ import csTools from 'cornerstone-tools';
 import { getEnabledElement } from './state';
 import waitForTheImageToBeRendered from './utils/waitForTheImageToBeRendered';
 
+import { planeIntersection } from './planeIntersection';
+
 const draw = csTools.importInternal('drawing/draw');
 const drawLine = csTools.importInternal('drawing/drawLine');
 const convertToVector3 = csTools.importInternal('util/convertToVector3');
-const planeIntersection = csTools.importInternal('util/planePlaneIntersection');
+// const planeIntersection = csTools.importInternal('util/planePlaneIntersection');
 const projectPatientPointToImagePlane = csTools.importInternal(
   'util/projectPatientPointToImagePlane'
 );

--- a/extensions/cornerstone/src/planeIntersection.js
+++ b/extensions/cornerstone/src/planeIntersection.js
@@ -1,0 +1,175 @@
+import csMath from 'cornerstone-math';
+
+/*
+TODO: The following functions are copied from the latest version of
+cornerstone-tools and placed here until we rebase our OHIF with the
+most up to date version
+*/
+
+export function planeIntersection(targetImagePlane, referenceImagePlane) {
+  const targetRowCosines = convertToVector3(targetImagePlane.rowCosines);
+  const targetColumnCosines = convertToVector3(targetImagePlane.columnCosines);
+  const targetImagePositionPatient = convertToVector3(
+    targetImagePlane.imagePositionPatient
+  );
+  const referenceRowCosines = convertToVector3(referenceImagePlane.rowCosines);
+  const referenceColumnCosines = convertToVector3(
+    referenceImagePlane.columnCosines
+  );
+  const referenceImagePositionPatient = convertToVector3(
+    referenceImagePlane.imagePositionPatient
+  );
+
+  // First, get the normals of each image plane
+  const targetNormal = targetRowCosines.clone().cross(targetColumnCosines);
+  const targetPlane = new csMath.Plane();
+
+  targetPlane.setFromNormalAndCoplanarPoint(
+    targetNormal,
+    targetImagePositionPatient
+  );
+
+  const referenceNormal = referenceRowCosines
+    .clone()
+    .cross(referenceColumnCosines);
+  const referencePlane = new csMath.Plane();
+
+  referencePlane.setFromNormalAndCoplanarPoint(
+    referenceNormal,
+    referenceImagePositionPatient
+  );
+
+  const originDirection = referencePlane.clone().intersectPlane(targetPlane);
+  const origin = originDirection.origin;
+  const direction = originDirection.direction;
+
+  // Calculate the longest possible length in the reference image plane (the length of the diagonal)
+  const bottomRight = imagePointToPatientPoint(
+    {
+      x: referenceImagePlane.columns,
+      y: referenceImagePlane.rows,
+    },
+    referenceImagePlane
+  );
+  const distance = referenceImagePositionPatient.distanceTo(bottomRight);
+
+  // Use this distance to bound the ray intersecting the two planes
+  const line = new csMath.Line3();
+
+  line.start = origin;
+  line.end = origin.clone().add(direction.multiplyScalar(distance));
+
+  // Find the intersections between this line and the reference image plane's four sides
+  const rect = getRectangleFromImagePlane(referenceImagePlane);
+  const intersections = lineRectangleIntersection(line, rect);
+
+  // Return the intersections between this line and the reference image plane's sides
+  // In order to draw the reference line from the target image.
+  if (intersections.length !== 2) {
+    return;
+  }
+
+  return {
+    start: intersections[0],
+    end: intersections[1],
+  };
+}
+
+function convertToVector3(arrayOrVector3) {
+  if (arrayOrVector3 instanceof csMath.Vector3) {
+    return arrayOrVector3;
+  }
+
+  const keys = Object.keys(arrayOrVector3);
+
+  if (keys.includes('x') && keys.includes('y') && keys.includes('z')) {
+    return new csMath.Vector3(
+      arrayOrVector3.x,
+      arrayOrVector3.y,
+      arrayOrVector3.z
+    );
+  }
+
+  return new csMath.Vector3(
+    arrayOrVector3[0],
+    arrayOrVector3[1],
+    arrayOrVector3[2]
+  );
+}
+
+function imagePointToPatientPoint(imagePoint, imagePlane) {
+  const rowCosines = convertToVector3(imagePlane.rowCosines);
+  const columnCosines = convertToVector3(imagePlane.columnCosines);
+  const imagePositionPatient = convertToVector3(
+    imagePlane.imagePositionPatient
+  );
+
+  const x = rowCosines.clone().multiplyScalar(imagePoint.x);
+
+  x.multiplyScalar(imagePlane.columnPixelSpacing);
+  const y = columnCosines.clone().multiplyScalar(imagePoint.y);
+
+  y.multiplyScalar(imagePlane.rowPixelSpacing);
+  const patientPoint = x.add(y);
+
+  patientPoint.add(imagePositionPatient);
+
+  return patientPoint;
+}
+
+function getRectangleFromImagePlane(imagePlane) {
+  // Get the points
+  const topLeft = imagePointToPatientPoint(
+    {
+      x: 0,
+      y: 0,
+    },
+    imagePlane
+  );
+  const topRight = imagePointToPatientPoint(
+    {
+      x: imagePlane.columns,
+      y: 0,
+    },
+    imagePlane
+  );
+  const bottomLeft = imagePointToPatientPoint(
+    {
+      x: 0,
+      y: imagePlane.rows,
+    },
+    imagePlane
+  );
+  const bottomRight = imagePointToPatientPoint(
+    {
+      x: imagePlane.columns,
+      y: imagePlane.rows,
+    },
+    imagePlane
+  );
+
+  // Get each side as a vector
+  const rect = {
+    top: new csMath.Line3(topLeft, topRight),
+    left: new csMath.Line3(topLeft, bottomLeft),
+    right: new csMath.Line3(topRight, bottomRight),
+    bottom: new csMath.Line3(bottomLeft, bottomRight),
+  };
+
+  return rect;
+}
+
+function lineRectangleIntersection(line, rect) {
+  const intersections = [];
+
+  Object.keys(rect).forEach(function(side) {
+    const segment = rect[side];
+    const intersection = line.intersectLine(segment);
+
+    if (intersection) {
+      intersections.push(intersection);
+    }
+  });
+
+  return intersections;
+}

--- a/extensions/dicom-sr/package.json
+++ b/extensions/dicom-sr/package.json
@@ -32,7 +32,7 @@
     "@ohif/core": "^0.50.0",
     "@ohif/ui": "^0.50.0",
     "cornerstone-core": "^2.3.0",
-    "cornerstone-math": "^0.1.9",
+    "cornerstone-math": "0.1.10",
     "cornerstone-tools": "5.1.2",
     "cornerstone-wado-image-loader": "^3.1.2",
     "dcmjs": "0.16.1",

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "cornerstone-core": "^2.3.0",
     "cornerstone-tools": "5.1.2",
-    "cornerstone-math": "0.1.9",
+    "cornerstone-math": "0.1.10",
     "cornerstone-wado-image-loader": "^3.1.2",
     "dicom-parser": "^1.8.3",
     "@ohif/ui": "^1.8.2"

--- a/platform/viewer/package.json
+++ b/platform/viewer/package.json
@@ -53,7 +53,7 @@
     "@types/react": "^16.0.0",
     "classnames": "^2.2.6",
     "core-js": "^3.2.1",
-    "cornerstone-math": "^0.1.9",
+    "cornerstone-math": "0.1.10",
     "cornerstone-tools": "5.1.2",
     "cornerstone-wado-image-loader": "^3.1.2",
     "dcmjs": "0.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3504,10 +3504,10 @@
     outvariant "^1.2.0"
     strict-event-emitter "^0.2.0"
 
-"@newlantern/viewer@^4.4.3":
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/@newlantern/viewer/-/viewer-4.4.3.tgz#a752a11e5ef5ce1b2dea4418e8d04a53391d654f"
-  integrity sha512-jlGn1y5ROGPHwmFuW2+xDK5SMfjysIwFLJ9ZapEqsLg01MuFYKdocG/BO+KhHohQMlEOTVl2RwYgW9l5i2/ktA==
+"@newlantern/viewer@^4.4.5":
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/@newlantern/viewer/-/viewer-4.4.6.tgz#9a30c9880a5082a36bd9cc4971e18f379d77f4b5"
+  integrity sha512-v3Le6Db4Ruk58wKlebFjF7P5/qcRQ0m7BGhiywlTl6yUXRlxUBV7iTeIfMgsj39fopmV+kV7pQ98EEd6L7S8QA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -4163,11 +4163,6 @@
     "@svgr/plugin-jsx" "^5.5.0"
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
-
-"@sweetalert2/theme-material-ui@^5.0.11":
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/@sweetalert2/theme-material-ui/-/theme-material-ui-5.0.11.tgz#3b3e85608b7259f72ac78949ede33fbaa78fca96"
-  integrity sha512-gVIwW2dDrQXz5pTYpm9fafIYuWv/K26q8/VsT1oSrJxLd5GKq9mrIbKENBcewiQGaCLC2t9uIZSX4HO1dRMHgg==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -7909,15 +7904,15 @@ cornerstone-core@2.3.0:
   resolved "https://registry.yarnpkg.com/cornerstone-core/-/cornerstone-core-2.3.0.tgz#b16430b0dc3883c795fbbd5f64d0f6357f91c889"
   integrity sha512-1LiCfRIlQvR1j8OhF7/3pvvQvvnTYZUywEkuoEo5K5mMrlKdrQMS75uW1uXb/nXShQDJyyjtTCQSVGgv2yHA+w==
 
+cornerstone-math@0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/cornerstone-math/-/cornerstone-math-0.1.10.tgz#a3f99db64d73c5adee61ae0d570128eca1682d07"
+  integrity sha512-23XSAyP7t70ANvhFyqwvva+zFd1bQ2d5GL7tg9qKE932WmImjA2Y9tiy5n0iTtnf51W/78Png8Lia2o4dCdJaQ==
+
 cornerstone-math@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/cornerstone-math/-/cornerstone-math-0.1.7.tgz#7c55536f02e7221b05fc49a4c780bb82c234ce39"
   integrity sha512-svsDSoqLNFM9niCV2AtV2DNmRkYztT1v80lVdbA5hkgdGdpWg5/h2On794zbqBK+aI3hNOHufERDsI4wdXGknA==
-
-cornerstone-math@^0.1.9:
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/cornerstone-math/-/cornerstone-math-0.1.9.tgz#7ce5509e8b9f465b01f7c548470725e7569859fc"
-  integrity sha512-NxdooV73asEQgav1S+0e+a4K+W3CXJdLXyFkVN24qqCtmIpzZzwtw3F9KWPCekzSAJmbhtQ3HicOQj3d4vRtuw==
 
 cornerstone-tools@5.1.2:
   version "5.1.2"
@@ -20527,10 +20522,10 @@ sass-loader@^10.0.5:
     schema-utils "^3.0.0"
     semver "^7.3.2"
 
-sass@1.51.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.51.0.tgz#25ea36cf819581fe1fe8329e8c3a4eaaf70d2845"
-  integrity sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==
+sass@^1.51.0:
+  version "1.52.3"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.52.3.tgz#b7cc7ffea2341ccc9a0c4fd372bf1b3f9be1b6cb"
+  integrity sha512-LNNPJ9lafx+j1ArtA7GyEJm9eawXN8KlA1+5dF6IZyoONg1Tyo/g+muOsENWJH/2Q1FHbbV4UwliU0cXMa/VIA==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
@@ -21876,10 +21871,10 @@ svgo@^2.7.0:
     picocolors "^1.0.0"
     stable "^0.1.8"
 
-sweetalert2@11.4.14:
-  version "11.4.14"
-  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-11.4.14.tgz#b7c7efbf6672aa56696ba68d7ac141798b961525"
-  integrity sha512-Dh4XqfUSpCwhRsGM5zZFbtBRHujjcaf98DjVKXEs0ER4E/Zao0OtDHZRRQqvT9xxY7RA8WsiZ6FHJbyW+BBbDw==
+sweetalert2@^11.4.14:
+  version "11.4.18"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-11.4.18.tgz#fd8f57adacffad472ff0e28d6fc029ad521d14b2"
+  integrity sha512-BZPTQI54NYdjIVe2tmsS5JVU7E623P3Sv4ce3BO8V6PdeIdGPGmQm43ojr1cnpGJ1xYhbdwsHIH+t5tICvZ6ZA==
 
 symbol-observable@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
This change fixes the reference lines tool. This is a temporary fix as we have had issues with upgrading to the latest version of cornerstone-tools in our OHIF fork. The temporary solution is to copy over the necessary intersection logic from cornerstone-tools and upgrade cornerstone-math. 

Later, when we rebase off of OHIF v3, we will remove this redundant code and import the intersection logic from cornerstone-tools as expected.