### PR TITLE
hot key validation errors resolved

### DIFF
--- a/platform/ui/src/components/HotkeysPreferences/HotkeysPreferences.jsx
+++ b/platform/ui/src/components/HotkeysPreferences/HotkeysPreferences.jsx
@@ -44,6 +44,8 @@ const HotkeysPreferences = ({
       }
     }
     if (firstErrorKey) {
+      // If we change the hotkey that is equal to the current error's tool value, 
+      // we update all errors to take on a new tool value
       const [errorToolName, errorKey] = extractInfoFromError(errors[firstErrorKey]);
       if (
         definition.keys.join('+') !== errorKey &&

--- a/platform/ui/src/components/HotkeysPreferences/utils.js
+++ b/platform/ui/src/components/HotkeysPreferences/utils.js
@@ -47,7 +47,7 @@ const validate = ({ commandName, pressedKeys, hotkeys }) => {
 };
 
 /**
- * Validate a hotkey change
+ * Extract relevant toolName and key data from a validation error
  *
  * @param {Object} error {error}
  * @returns {array} [toolName, key] toolName and key from error

--- a/platform/ui/src/components/HotkeysPreferences/utils.js
+++ b/platform/ui/src/components/HotkeysPreferences/utils.js
@@ -22,28 +22,74 @@ const splitHotkeyDefinitionsAndCreateTuples = hotkeyDefinitions => {
 };
 
 /**
+ * Remove validation errors as necessary
+ *
+ * @param {Object} currentErrors
+ * @param {array} pressedKeys new keys
+ * @param {string} id id
+ * @param {array} arguments.hotkeys current hotkeys
+ * @returns {Object} {error} validation error
+ */
+const removeErrors = (currentErrors, pressedKeys, id, hotkeys) => {
+  const pressedLabel = hotkeys[id].label;
+  let newLabel;
+  if (Object.keys(currentErrors.currentErrors).length) {
+    // First delete the error once we delete the error
+    Object.keys(currentErrors.currentErrors).every((key) => {
+      if (currentErrors.currentErrors[key]) {
+        const [errorLabel, errorKeys] = extractInfoFromError(currentErrors.currentErrors[key]);
+        if (errorLabel === pressedLabel && pressedKeys.join("+") !== errorKeys) {
+          hotkeys[key]
+          newLabel = hotkeys[key].label
+          currentErrors.currentErrors[key] = undefined
+          return false
+        }
+      }
+      return true
+    })
+    // Then we relabel old errors so that all duplicate keys have the same error
+    Object.keys(currentErrors.currentErrors).forEach((key) => {
+      const error = currentErrors.currentErrors[key]
+      if (error) {
+        const [errorLabel, errorKeys] = extractInfoFromError(error);
+        if (errorLabel === pressedLabel && pressedKeys.join("+") !== errorKeys) { 
+          currentErrors.currentErrors[key] = currentErrors.currentErrors[key].replace(
+            `"${errorLabel}"`,
+            `"${newLabel}"`
+          )
+        }
+      }
+    })
+  }
+  
+  return {currentErrors: currentErrors}
+}
+
+/**
  * Validate a hotkey change
  *
  * @param {Object} arguments
  * @param {string} arguments.commandName command name or id
  * @param {array} arguments.pressedKeys new keys
  * @param {array} arguments.hotkeys current hotkeys
+ * @param {Object} currentErrors
  * @returns {Object} {error} validation error
  */
-const validate = ({ commandName, pressedKeys, hotkeys }) => {
+const validate = ({ commandName, pressedKeys, hotkeys, currentErrors }) => {
+  
+  const updatedErrors = removeErrors(currentErrors, pressedKeys, commandName, hotkeys)
   for (const validator of hotkeysValidators) {
     const validation = validator({
       commandName,
       pressedKeys,
-      hotkeys,
+      hotkeys
     });
-
+    
     if (validation && validation.error) {
-      console.log('VERROR', validation);
-      return validation;
+      return {...validation, ...updatedErrors};
     }
   }
-  return { error: undefined };
+  return { error: undefined, ...updatedErrors };
 };
 
 /**


### PR DESCRIPTION
I fixed the hotkey validation error. This would occur when resolving an error by changing a hotkey on the item that wasn't displaying the error. I do this by deleting an error if the user resolves an error by changing a hotkey for any tool name. And I also update the error states to include a new toolName in the case that there are multiple duplicate hotkeys.

It may be more generalizable to  pass conflictingCommand.label and pressedKeys as values in the error messages rather than extracting them from the string but I wasn't sure about changing the entire errors object Let me know any thoughts.

@kevinshen1101
  
<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
