### PR TITLE
Bug/hold mic while mousemove

### DIFF
--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -339,7 +339,8 @@ function commandsModule({
         if (activeToolName === 'Crosshairs') {
           toolGroup.setToolDisabled(activeToolName);
         } else {
-          toolGroup.setToolPassive(activeToolName);
+          // We remove all bindings so that bindings from this tool don't override the bindings of the new tool
+          toolGroup.setToolPassive(activeToolName, { removeAllBindings: true });
         }
       }
 
@@ -355,6 +356,11 @@ function commandsModule({
         bindings: [
           {
             mouseButton: Enums.MouseBindings.Primary,
+          },
+          // We add the command key binding so that the tool works while holding the record button on powermic
+          {
+            mouseButton: Enums.MouseBindings.Primary,
+            modifierKey: 91, // Command key on Macs
           },
         ],
       });

--- a/platform/core/src/services/ToolBarService/ToolbarService.ts
+++ b/platform/core/src/services/ToolBarService/ToolbarService.ts
@@ -107,7 +107,6 @@ export default class ToolbarService extends PubSubService {
   }
 
   public onModeEnter(): void {
-    console.log('ENTER');
     this.reset();
   }
 

--- a/platform/core/src/services/ToolBarService/ToolbarService.ts
+++ b/platform/core/src/services/ToolBarService/ToolbarService.ts
@@ -107,6 +107,7 @@ export default class ToolbarService extends PubSubService {
   }
 
   public onModeEnter(): void {
+    console.log('ENTER');
     this.reset();
   }
 


### PR DESCRIPTION
While holding record on the microphone, rads were unable to interact with the viewer (i.e. stack scroll, window width, etc.). This is because the record button on the microphone simulates the key press of Cmd + F11, and the command key was blocking actions in the viewer. To fix this, I add the command modifier key as a binding when they select a tool, and I remove it when they unselect a tool.